### PR TITLE
Save with ctrl return

### DIFF
--- a/src/autotype/AutoTypeSelectDialog.cpp
+++ b/src/autotype/AutoTypeSelectDialog.cpp
@@ -20,10 +20,12 @@
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QDialogButtonBox>
+#include <QHeaderView>
 #include <QLabel>
 #include <QVBoxLayout>
 
 #include "autotype/AutoTypeSelectView.h"
+#include "core/Config.h"
 #include "core/FilePath.h"
 #include "gui/entry/EntryModel.h"
 
@@ -39,11 +41,14 @@ AutoTypeSelectDialog::AutoTypeSelectDialog(QWidget* parent)
     setWindowTitle(tr("Auto-Type - KeePassX"));
     setWindowIcon(filePath()->applicationIcon());
 
-    QSize size(400, 250);
+    QRect screenGeometry = QApplication::desktop()->availableGeometry(QCursor::pos());
+    QSize size = config()->get("GUI/AutoTypeSelectDialogSize", QSize(400, 250)).toSize();
+    size.setWidth(qMin(size.width(), screenGeometry.width()));
+    size.setHeight(qMin(size.height(), screenGeometry.height()));
     resize(size);
 
     // move dialog to the center of the screen
-    QPoint screenCenter = QApplication::desktop()->availableGeometry(QCursor::pos()).center();
+    QPoint screenCenter = screenGeometry.center();
     move(screenCenter.x() - (size.width() / 2), screenCenter.y() - (size.height() / 2));
 
     QVBoxLayout* layout = new QVBoxLayout(this);
@@ -65,6 +70,15 @@ void AutoTypeSelectDialog::setEntries(const QList<Entry*>& entries, const QHash<
 {
     m_sequences = sequences;
     m_view->setEntryList(entries);
+
+    m_view->header()->resizeSections(QHeaderView::ResizeToContents);
+}
+
+void AutoTypeSelectDialog::done(int r)
+{
+    config()->set("GUI/AutoTypeSelectDialogSize", size());
+
+    QDialog::done(r);
 }
 
 void AutoTypeSelectDialog::emitEntryActivated(const QModelIndex& index)

--- a/src/autotype/AutoTypeSelectDialog.h
+++ b/src/autotype/AutoTypeSelectDialog.h
@@ -36,6 +36,9 @@ public:
 Q_SIGNALS:
     void entryActivated(Entry* entry, const QString& sequence);
 
+public Q_SLOTS:
+    void done(int r) override;
+
 private Q_SLOTS:
     void emitEntryActivated(const QModelIndex& index);
     void entryRemoved();

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -98,6 +98,11 @@ void EditEntryWidget::setupMain()
     m_mainUi->expirePresets->setMenu(createPresetsMenu());
     connect(m_mainUi->expirePresets->menu(), SIGNAL(triggered(QAction*)), this, SLOT(useExpiryPreset(QAction*)));
 
+    QAction *action = new QAction(this);
+    action->setShortcut(Qt::CTRL | Qt::Key_Return);
+    connect(action, SIGNAL(triggered()), this, SLOT(saveEntry()));
+    this->addAction(action);
+
     m_mainUi->passwordGenerator->hide();
     m_mainUi->passwordGenerator->reset();
 }


### PR DESCRIPTION
This is rebased to a slightly newer point in history in upstream than this repo it seems. I can rebase it to your master if that's more convenient.

The point is simply to quit and save entry editing when hitting ctrl+return on the text area for notes.