### PR TITLE
add libmicrohttpd-dev on debian installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following libraries are required:
 On Debian you can install them with:
 
 ```bash
-sudo apt-get install build-essential cmake qtbase5-dev libqt5x11extras5-dev qttools5-dev qttools5-dev-tools libgcrypt20-dev zlib1g-dev
+sudo apt-get install build-essential cmake qtbase5-dev libqt5x11extras5-dev qttools5-dev qttools5-dev-tools libgcrypt20-dev zlib1g-dev libmicrohttpd-dev
 ```
 
 #### Build Steps


### PR DESCRIPTION
Just an easy fix on debian install command to compile without errors with the required package as said on README.