### PR TITLE
Fetch favicon from the root of the website and use Google as a fallback

### DIFF
--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -141,30 +141,42 @@ void EditWidgetIcons::setUrl(const QString &url)
     abortFaviconDownload();
 }
 
-void EditWidgetIcons::downloadFavicon()
+void EditWidgetIcons::downloadFavicon(QUrl url)
 {
     if (m_networkOperation == nullptr) {
-        QUrl url(m_url);
-        QString path = "http://www.google.com/s2/favicons?domain=" + url.host();
-
-        m_networkOperation = m_networkAccessMngr->get(QNetworkRequest(path));
+    
+        if (url.isEmpty()) {
+            url = QUrl(m_url);
+            url.setPath("/favicon.ico");
+        }
+        
+        m_networkOperation = m_networkAccessMngr->get(QNetworkRequest(url));
         m_ui->faviconButton->setDisabled(true);
     }
 }
 
-void EditWidgetIcons::abortFaviconDownload()
+void EditWidgetIcons::abortFaviconDownload(bool clearRedirect)
 {
     if (m_networkOperation != nullptr) {
         m_networkOperation->abort();
         m_networkOperation->deleteLater();
         m_networkOperation = nullptr;
     }
+    
+    if (clearRedirect) {
+        if (!redirectUrl.isEmpty()) {
+            redirectUrl.clear();
+        }
+        redirectCount = 0;
+    }
+    
+    fallbackToGoogle = true;
     m_ui->faviconButton->setDisabled(false);
 }
 
 void EditWidgetIcons::onRequestFinished(QNetworkReply *reply)
 {
-    if (!reply->error()) {
+    if (!reply->error()) {    
         QImage image;
         image.loadFromData(reply->readAll());
 
@@ -177,10 +189,42 @@ void EditWidgetIcons::onRequestFinished(QNetworkReply *reply)
             QModelIndex index = m_customIconModel->indexFromUuid(uuid);
             m_ui->customIconsView->setCurrentIndex(index);
             m_ui->customIconsRadio->setChecked(true);
+            
+            abortFaviconDownload();
+        }
+        else {
+            // Check if server has sent a redirect
+            QUrl possibleRedirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+            if (!possibleRedirectUrl.isEmpty() && possibleRedirectUrl != redirectUrl && redirectCount < 3) {
+                abortFaviconDownload(false);
+                redirectUrl = possibleRedirectUrl;
+                ++redirectCount;
+                downloadFavicon(redirectUrl);
+            }
+            else { // Webpage is trying to redirect back to itself or the maximum number of redirects has been reached, fallback to Google
+                if (fallbackToGoogle) {
+                    abortFaviconDownload();
+                    fallbackToGoogle = false;
+                    downloadFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + reply->url().host()));
+                }
+                else {
+                    abortFaviconDownload();
+                    MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
+                }
+            }
         }
     }
-
-    abortFaviconDownload();
+    else { // Request Error e.g. 404, fallback to Google
+        if (fallbackToGoogle) {
+            abortFaviconDownload();
+            fallbackToGoogle = false;
+            downloadFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + reply->url().host()));
+        }
+        else {
+            abortFaviconDownload();
+            MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
+        }
+    }
 }
 
 void EditWidgetIcons::addCustomIcon()

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -141,17 +141,31 @@ void EditWidgetIcons::setUrl(const QString &url)
     abortFaviconDownload();
 }
 
-void EditWidgetIcons::downloadFavicon(QUrl url)
+void EditWidgetIcons::downloadFavicon()
+{
+    QUrl url = QUrl(m_url);
+    url.setPath("/favicon.ico");
+    fetchFavicon(url);
+}
+
+void EditWidgetIcons::fetchFavicon(QUrl url)
 {
     if (m_networkOperation == nullptr) {
-    
-        if (url.isEmpty()) {
-            url = QUrl(m_url);
-            url.setPath("/favicon.ico");
-        }
-        
         m_networkOperation = m_networkAccessMngr->get(QNetworkRequest(url));
         m_ui->faviconButton->setDisabled(true);
+    }
+}
+
+void EditWidgetIcons::fetchFaviconFromGoogle(QString domain)
+{
+     if (m_fallbackToGoogle) {
+        abortFaviconDownload();
+        m_fallbackToGoogle = false;
+        fetchFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + domain));
+    }
+    else {
+        abortFaviconDownload();
+        MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
     }
 }
 
@@ -199,31 +213,15 @@ void EditWidgetIcons::onRequestFinished(QNetworkReply *reply)
                 abortFaviconDownload(false);
                 m_redirectUrl = possibleRedirectUrl;
                 ++m_redirectCount;
-                downloadFavicon(m_redirectUrl);
+                fetchFavicon(m_redirectUrl);
             }
             else { // Webpage is trying to redirect back to itself or the maximum number of redirects has been reached, fallback to Google
-                if (m_fallbackToGoogle) {
-                    abortFaviconDownload();
-                    m_fallbackToGoogle = false;
-                    downloadFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + reply->url().host()));
-                }
-                else {
-                    abortFaviconDownload();
-                    MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
-                }
+                fetchFaviconFromGoogle(reply->url().host());
             }
         }
     }
     else { // Request Error e.g. 404, fallback to Google
-        if (m_fallbackToGoogle) {
-            abortFaviconDownload();
-            m_fallbackToGoogle = false;
-            downloadFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + reply->url().host()));
-        }
-        else {
-            abortFaviconDownload();
-            MessageBox::warning(this, tr("Error"), tr("Unable to fetch favicon."));
-        }
+        fetchFaviconFromGoogle(reply->url().host());
     }
 }
 

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -164,13 +164,13 @@ void EditWidgetIcons::abortFaviconDownload(bool clearRedirect)
     }
     
     if (clearRedirect) {
-        if (!redirectUrl.isEmpty()) {
-            redirectUrl.clear();
+        if (!m_redirectUrl.isEmpty()) {
+            m_redirectUrl.clear();
         }
-        redirectCount = 0;
+        m_redirectCount = 0;
     }
     
-    fallbackToGoogle = true;
+    m_fallbackToGoogle = true;
     m_ui->faviconButton->setDisabled(false);
 }
 
@@ -195,16 +195,16 @@ void EditWidgetIcons::onRequestFinished(QNetworkReply *reply)
         else {
             // Check if server has sent a redirect
             QUrl possibleRedirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
-            if (!possibleRedirectUrl.isEmpty() && possibleRedirectUrl != redirectUrl && redirectCount < 3) {
+            if (!possibleRedirectUrl.isEmpty() && possibleRedirectUrl != m_redirectUrl && m_redirectCount < 3) {
                 abortFaviconDownload(false);
-                redirectUrl = possibleRedirectUrl;
-                ++redirectCount;
-                downloadFavicon(redirectUrl);
+                m_redirectUrl = possibleRedirectUrl;
+                ++m_redirectCount;
+                downloadFavicon(m_redirectUrl);
             }
             else { // Webpage is trying to redirect back to itself or the maximum number of redirects has been reached, fallback to Google
-                if (fallbackToGoogle) {
+                if (m_fallbackToGoogle) {
                     abortFaviconDownload();
-                    fallbackToGoogle = false;
+                    m_fallbackToGoogle = false;
                     downloadFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + reply->url().host()));
                 }
                 else {
@@ -215,9 +215,9 @@ void EditWidgetIcons::onRequestFinished(QNetworkReply *reply)
         }
     }
     else { // Request Error e.g. 404, fallback to Google
-        if (fallbackToGoogle) {
+        if (m_fallbackToGoogle) {
             abortFaviconDownload();
-            fallbackToGoogle = false;
+            m_fallbackToGoogle = false;
             downloadFavicon(QUrl("http://www.google.com/s2/favicons?domain=" + reply->url().host()));
         }
         else {

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -60,7 +60,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void downloadFavicon();
-    void fetchFavicon(QUrl url = QUrl());
+    void fetchFavicon(QUrl url);
     void fetchFaviconFromGoogle(QString domain);
     void abortFaviconDownload(bool clearRedirect = true);
     void onRequestFinished(QNetworkReply *reply);

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -74,9 +74,9 @@ private:
     Database* m_database;
     Uuid m_currentUuid;
     QString m_url;
-    QUrl redirectUrl;
-    bool fallbackToGoogle = true;
-    unsigned short redirectCount = 0;
+    QUrl m_redirectUrl;
+    bool m_fallbackToGoogle = true;
+    unsigned short m_redirectCount = 0;
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
     QNetworkAccessManager* const m_networkAccessMngr;

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -59,8 +59,8 @@ public Q_SLOTS:
     void setUrl(const QString &url);
 
 private Q_SLOTS:
-    void downloadFavicon();
-    void abortFaviconDownload();
+    void downloadFavicon(QUrl url = QUrl());
+    void abortFaviconDownload(bool clearRedirect = true);
     void onRequestFinished(QNetworkReply *reply);
     void addCustomIcon();
     void removeCustomIcon();
@@ -74,6 +74,9 @@ private:
     Database* m_database;
     Uuid m_currentUuid;
     QString m_url;
+    QUrl redirectUrl;
+    bool fallbackToGoogle = true;
+    unsigned short redirectCount = 0;
     DefaultIconModel* const m_defaultIconModel;
     CustomIconModel* const m_customIconModel;
     QNetworkAccessManager* const m_networkAccessMngr;

--- a/src/gui/EditWidgetIcons.h
+++ b/src/gui/EditWidgetIcons.h
@@ -59,7 +59,9 @@ public Q_SLOTS:
     void setUrl(const QString &url);
 
 private Q_SLOTS:
-    void downloadFavicon(QUrl url = QUrl());
+    void downloadFavicon();
+    void fetchFavicon(QUrl url = QUrl());
+    void fetchFaviconFromGoogle(QString domain);
     void abortFaviconDownload(bool clearRedirect = true);
     void onRequestFinished(QNetworkReply *reply);
     void addCustomIcon();


### PR DESCRIPTION
* Replace favicon fetching using Google with fetching from the root of the website
* Follow up to 3 http redirects for the favicon
* Add download favicon from Google as fallback

#32 