### PR TITLE
Fix winsock and autotype error when compiling on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ if(MINGW)
   set(CMAKE_RC_COMPILER_INIT windres)
   enable_language(RC)
   set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> <FLAGS> -O coff <DEFINES> -i <SOURCE> -o <OBJECT>")
+  link_libraries(ws2_32 wsock32)
 endif()
 
 if(APPLE OR MINGW)
@@ -201,7 +202,7 @@ if(UNIX)
   endif()
 endif()
 
-include_directories(SYSTEM ${GCRYPT_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
+include_directories(SYSTEM ${GCRYPT_INCLUDE_DIR} ${MHD_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
 
 include(FeatureSummary)
 

--- a/src/autotype/CMakeLists.txt
+++ b/src/autotype/CMakeLists.txt
@@ -13,5 +13,8 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(WITH_TESTS)
-  add_subdirectory(test)
+  # autotype non supported on Windows right now
+  if(UNIX)
+    add_subdirectory(test)
+  endif()
 endif()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -717,8 +717,8 @@ void MainWindow::repairDatabase()
             KeePass2Writer writer;
             writer.writeDatabase(saveFileName, dbRepairWidget->database());
             if (writer.hasError()) {
-                MessageBox::critical(this, tr("Error"), tr("Writing the database failed.") + "\n\n"
-                                     + writer.errorString());
+                QMessageBox::critical(this, tr("Error"),
+                    tr("Writing the database failed.").append("\n\n").append(writer.errorString()));
             }
         }
     }

--- a/src/http/Server.cpp
+++ b/src/http/Server.cpp
@@ -22,7 +22,12 @@
 #include <QEventLoop>
 #include <QtNetwork/QHostInfo>
 #include <QtNetwork/QHostAddress>
+
+#ifdef Q_OS_WIN
+#include <winsock2.h>
+#else
 #include <netinet/in.h>
+#endif
 
 using namespace KeepassHttpProtocol;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When compiling on Windows, the build fails for 2 motive:

* Autotype on Windows isn't implemented yet but Cmake tries to build its tests anyway
* keepassxhttp uses **netinet/in.h** header file for **sockaddr_in** struct. <br/>This file is not available on Windows, where instead the struct is defined in the **winsock2.h** header

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
on Windows:
 * Building KeePassXR was broken due to keepassxhttp.
 * Tests were broken due to Autotype.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
