### PR TITLE
add command line option --pw-stdin to accept password from stdin

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 
 #include <QCommandLineParser>
 #include <QFile>
+#include <QTextStream>
 
 #include "config-keepassx.h"
 #include "core/Config.h"
@@ -61,11 +62,14 @@ int main(int argc, char** argv)
     QCommandLineOption keyfileOption("keyfile",
                                      QCoreApplication::translate("main", "key file of the database"),
                                      "keyfile");
+    QCommandLineOption pwstdinOption("pw-stdin",
+                                     QCoreApplication::translate("main", "read password of the database from stdin"));
 
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addOption(configOption);
     parser.addOption(keyfileOption);
+    parser.addOption(pwstdinOption);
 
     parser.process(app);
     const QStringList args = parser.positionalArguments();
@@ -90,7 +94,12 @@ int main(int argc, char** argv)
     for (int ii=0; ii < args.length(); ii++) {
         QString filename = args[ii];
         if (!filename.isEmpty() && QFile::exists(filename)) {
-            mainWindow.openDatabase(filename, QString(), parser.value(keyfileOption));
+            QString password;
+            if (parser.isSet(pwstdinOption)) {
+                static QTextStream in(stdin, QIODevice::ReadOnly);
+                password = in.readLine();
+            }
+            mainWindow.openDatabase(filename, password, parser.value(keyfileOption));
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
for each database listed as a parameter read a line from stdin as the password.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
the original KeePass could accept database passwords from stdin which mitigates exposing password via environment.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
i originally submitted a version this change in https://github.com/keepassx/keepassx/pull/167, 02 Jun 16, after using it personally for a few months prior.  i use this daily with a frontend script that pulls passwords from kwallet.
<!--- Include details of your testing environment, and the tests you ran to -->
my environment is openSUSE Leap 42.1 using KDE.
<!--- see how your change affects other areas of the code, etc. -->
the scope of the change is very limited and the default behavior is preserved.  nowhere else do i find reference to stdin or cin so it should not affect other areas of the code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

