### PR TITLE
utility to launch keepassx with database passwords fetched from kdewa…

### DIFF
--- a/utils/keepassx-kwallet
+++ b/utils/keepassx-kwallet
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+PROG="$(basename $0)"
+
+function daemon_main {
+  # open kdewallet
+  handle=$(qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.open kdewallet 0 "$PROG")
+  while [[ true != $(qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.isOpen kdewallet) ]]; do
+    sleep 1
+  done
+
+  # fetch KeePass database passwords from kdewallet
+  declare -A DBs
+  ### change the path to suit your installation ###
+  for DBPATH in ~/.keepassx/*.kdbx; do
+    DBs[$DBPATH]=$(qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.readPassword "$handle" "Passwords" "$DBPATH" "$PROG")
+  done
+
+  # launch keepassx
+  IFS=$'\n\n\n'
+  keepassx --pw-stdin "${!DBs[@]}" <<<"${DBs[*]}" &
+
+  # done with kdewallet
+  qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.close "$handle" "false" "$PROG"
+}
+
+if [[ '-d' = "$1" ]]; then
+  exec >&~/tmp/$PROG.log
+  set -vx
+  daemon_main
+else
+  cd /
+  daemon_main </dev/null >&/dev/null &
+  disown
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
this utility opens KeePass databases automagically:

- find kdbx files in the filesystem,
- look up their passwords stored in kdewallet,
- use the --pw-stdin feature to launch keepassx.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
i use lengthy randomly generated passwords for my kdbx files.  instead of keeping the plaintext passwords in a file or email or some such i use the kwallet system to encrypt them and this script to decrypt and launch keepassx on the fly.  the --pw-stdin feature keeps the passwords out of the environment where they might be visible.
<!--- If it fixes an open issue, please link to the issue here. -->
@droidmonkey and i discussed this briefly at https://github.com/keepassxreboot/keepassx/pull/54#issuecomment-255886311

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
i use this script every day with multiple databases.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
since the script is outside keepassx the worst that can happen is a failed launch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

…llet