### PR TITLE
Implement automatic locking when minimizing

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -101,6 +101,7 @@ void Config::init(const QString& fileName)
     m_defaults.insert("security/clearclipboardtimeout", 10);
     m_defaults.insert("security/lockdatabaseidle", false);
     m_defaults.insert("security/lockdatabaseidlesec", 10);
+    m_defaults.insert("security/lockdatabaseminimize", false);
     m_defaults.insert("security/passwordscleartext", false);
     m_defaults.insert("security/autotypeask", true);
     m_defaults.insert("GUI/Language", "system");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -516,6 +516,11 @@ void MainWindow::closeEvent(QCloseEvent* event)
     {
         event->ignore();
         hide();
+
+        if (config()->get("security/lockdatabaseminimize").toBool()) {
+            m_ui->tabWidget->lockDatabases();
+        }
+
         return;
     }
 
@@ -534,12 +539,17 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
 void MainWindow::changeEvent(QEvent* event)
 {
-    if ((event->type() == QEvent::WindowStateChange) && isMinimized()
-            && isTrayIconEnabled() && m_trayIcon && m_trayIcon->isVisible()
-            && config()->get("GUI/MinimizeToTray").toBool())
-    {
-        event->ignore();
-        QTimer::singleShot(0, this, SLOT(hide()));
+    if ((event->type() == QEvent::WindowStateChange) && isMinimized()) {
+        if (isTrayIconEnabled() && m_trayIcon && m_trayIcon->isVisible()
+                && config()->get("GUI/MinimizeToTray").toBool())
+        {
+            event->ignore();
+            QTimer::singleShot(0, this, SLOT(hide()));
+        }
+
+        if (config()->get("security/lockdatabaseminimize").toBool()) {
+            m_ui->tabWidget->lockDatabases();
+        }
     }
     else {
         QMainWindow::changeEvent(event);
@@ -674,6 +684,10 @@ void MainWindow::toggleWindow()
 {
     if ((QApplication::activeWindow() == this) && isVisible() && !isMinimized()) {
         hide();
+
+        if (config()->get("security/lockdatabaseminimize").toBool()) {
+            m_ui->tabWidget->lockDatabases();
+        }
     }
     else {
         ensurePolished();

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -142,6 +142,7 @@ void SettingsWidget::loadSettings()
 
     m_secUi->lockDatabaseIdleCheckBox->setChecked(config()->get("security/lockdatabaseidle").toBool());
     m_secUi->lockDatabaseIdleSpinBox->setValue(config()->get("security/lockdatabaseidlesec").toInt());
+    m_secUi->lockDatabaseMinimizeCheckBox->setChecked(config()->get("security/lockdatabaseminimize").toBool());
 
     m_secUi->passwordCleartextCheckBox->setChecked(config()->get("security/passwordscleartext").toBool());
 
@@ -185,6 +186,7 @@ void SettingsWidget::saveSettings()
 
     config()->set("security/lockdatabaseidle", m_secUi->lockDatabaseIdleCheckBox->isChecked());
     config()->set("security/lockdatabaseidlesec", m_secUi->lockDatabaseIdleSpinBox->value());
+    config()->set("security/lockdatabaseminimize", m_secUi->lockDatabaseMinimizeCheckBox->isChecked());
 
     config()->set("security/passwordscleartext", m_secUi->passwordCleartextCheckBox->isChecked());
 

--- a/src/gui/SettingsWidgetSecurity.ui
+++ b/src/gui/SettingsWidgetSecurity.ui
@@ -58,13 +58,20 @@
     </widget>
    </item>
    <item row="2" column="0">
+    <widget class="QCheckBox" name="lockDatabaseMinimizeCheckBox">
+     <property name="text">
+      <string>Lock databases after minimizing the window</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QCheckBox" name="passwordCleartextCheckBox">
      <property name="text">
       <string>Show passwords in cleartext by default</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QCheckBox" name="autoTypeAskCheckBox">
      <property name="text">
       <string>Always ask before performing auto-type</string>


### PR DESCRIPTION
## Description
This PR adds two security-related options: _Lock databases after minimizing to system tray_ and _Lock databases after minimizing to taskbar_.

The autolocking is suspended when GUI/MinimizeOnStartup is true (or to be more precise, _MainWindow::configuredMinimizeWindow()_ is left intact), as it wouldn't make much sense to lock the DB right after unlocking it.

## Motivation and Context
It enables additional workflows for using this program, and is implemented in the original KeePass as well.

## How Has This Been Tested?
Manually tested all possible combinations of the following settings:
_GUI/MinimizeOnClose
GUI/MinimizeOnStartup
GUI/MinimizeToTray
security/lockdatabasetray
security/lockdatabaseminimize_

## Types of changes
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:` -->
- New feature (non-breaking change which adds functionality)

## Checklist:
- :white_check_mark: My code follows the code style of this project.
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :white_check_mark: I have read the **CONTRIBUTING** document.
- :negative_squared_cross_mark: I have added tests to cover my changes.
- :white_check_mark: All new and existing tests passed.

Could you please review the PR and merge if deemed appropriate? Thank you.