### PR TITLE
search directory configured via environment

### DIFF
--- a/utils/keepassx-kwallet
+++ b/utils/keepassx-kwallet
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+### change the path to suit your installation or set KDBX_SEARCH before calling ###
+: ${KDBX_SEARCH:=~/.KeePass/*.kdbx}
+
 PROG="$(basename $0)"
 
 function daemon_main {
@@ -11,8 +14,8 @@ function daemon_main {
 
   # fetch KeePass database passwords from kdewallet
   declare -A DBs
-  ### change the path to suit your installation ###
-  for DBPATH in ~/.keepassx/*.kdbx; do
+  for DBPATH in $KDBX_SEARCH; do
+    [[ -L "$DBPATH" ]] && DBPATH=$(readlink --canonicalize "$DBPATH")
     DBs[$DBPATH]=$(qdbus org.kde.kwalletd5 /modules/kwalletd5 org.kde.KWallet.readPassword "$handle" "Passwords" "$DBPATH" "$PROG")
   done
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
default an environment variable to provide search path
canonicalize database paths

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
requested in https://github.com/keepassxreboot/keepassx/pull/55
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
not much, really, but enough to discover the need to canonicalize.
<!--- Include details of your testing environment, and the tests you ran to -->
openSUSE Linux Leap 42.1
<!--- see how your change affects other areas of the code, etc. -->
since this is external to keepassx i cannot imagine it affects too much of anything

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

use absolute path to database file