### PR TITLE
Fix advanced HTTP settings (close #34)

### DIFF
--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -23,10 +23,6 @@
 #include "core/Config.h"
 #include "core/Translator.h"
 
-#include "http/OptionDialog.h"
-
-#include "http/HttpSettings.h"
-
 class SettingsWidget::ExtraPage
 {
     public:

--- a/src/http/HttpSettings.cpp
+++ b/src/http/HttpSettings.cpp
@@ -103,7 +103,7 @@ bool HttpSettings::alwaysAllowUpdate()
 
 void HttpSettings::setAlwaysAllowUpdate(bool alwaysAllowUpdate)
 {
-    config()->set("Http/AlwaysAllowAccess", alwaysAllowUpdate);
+    config()->set("Http/AlwaysAllowUpdate", alwaysAllowUpdate);
 }
 
 bool HttpSettings::searchInAllDatabases()

--- a/src/http/OptionDialog.cpp
+++ b/src/http/OptionDialog.cpp
@@ -57,6 +57,7 @@ void OptionDialog::loadSettings()
     ui->alwaysAllowAccess->setChecked(settings.alwaysAllowAccess());
     ui->alwaysAllowUpdate->setChecked(settings.alwaysAllowUpdate());
     ui->searchInAllDatabases->setChecked(settings.searchInAllDatabases());
+    ui->supportKphFields->setChecked(settings.supportKphFields());
 }
 
 void OptionDialog::saveSettings()
@@ -85,4 +86,5 @@ void OptionDialog::saveSettings()
     settings.setAlwaysAllowAccess(ui->alwaysAllowAccess->isChecked());
     settings.setAlwaysAllowUpdate(ui->alwaysAllowUpdate->isChecked());
     settings.setSearchInAllDatabases(ui->searchInAllDatabases->isChecked());
+    settings.setSupportKphFields(ui->supportKphFields->isChecked());
 }


### PR DESCRIPTION
Fixes some advanced HTTP settings not being remembered.

## Motivation and Context
Fixes #34 

## How Has This Been Tested?
Manually tested whether the settings are remembered.

## Types of changes
<!--- What types of changes does your code introduce? If it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:` -->
<!--- Everybody loves emoji -->
- :white_check_mark: Bug fix (non-breaking change which fixes an issue)
- :negative_squared_cross_mark: New feature (non-breaking change which adds functionality)
- :negative_squared_cross_mark: Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, if it apply to your pull request, -->
<!--- replace all the `:negative_squared_cross_mark:` with `:white_check_mark:`. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Pull Requests that fail the [REQUIRED] field will likely be sent back for corrections or rejected  -->
- :white_check_mark: I have read the **CONTRIBUTING** document. [REQUIRED]
- :white_check_mark: My code follows the code style of this project. [REQUIRED]
- :white_check_mark: All new and existing tests passed. [REQUIRED]
- :negative_squared_cross_mark: My change requires a change to the documentation.
- :negative_squared_cross_mark: I have updated the documentation accordingly.
- :negative_squared_cross_mark: I have added tests to cover my changes.

